### PR TITLE
checkbox label 클릭 stopPropagation 추가

### DIFF
--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -3,7 +3,10 @@ import type { CheckboxProps } from '../../types/checkbox.interface';
 
 const Checkbox = ({ checked, setChecked, disabled, className }: CheckboxProps) => {
   return (
-    <label className={`fc-checkbox ${className} ${checked ? 'checked' : ''} ${disabled ? 'disabled' : ''}`}>
+    <label
+      className={`fc-checkbox ${className} ${checked ? 'checked' : ''} ${disabled ? 'disabled' : ''}`}
+      onClick={(e) => e.stopPropagation()}
+    >
       <input type="checkbox" checked={checked} disabled={disabled} onChange={(e) => setChecked(e.target.checked)} />
     </label>
   );


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정

## 관련된 이슈를 이야기해주세요.

## 코드의 실행결과를 볼 수 있는 스크린샷이 있을까요?

## 무엇이 변경되었나요?

* checkbox label 클릭 이벤트 발생하면 이벤트 전파하지 않도록 수정

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

<img width="57" alt="image" src="https://user-images.githubusercontent.com/34783156/155098880-090f80b1-7ad9-4fa8-ac57-fdf10ad30e1f.png">

checkbox 컴포넌트 만들면서 label 바깥 영역을 클릭했을 때도 체크되도록 이벤트를 연결.
label영역 클릭하면 바깥영역 이벤트와 checkbox 내부 label 이벤트 중복 발생해서 체크가 안됨
하나만 발생할 수 있도록 수정

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

로컬 테스트
