### PR TITLE
fix: player errorHandler추가 및 생성자 호출 시점 변경

### DIFF
--- a/src/components/player/kollus.tsx
+++ b/src/components/player/kollus.tsx
@@ -45,14 +45,18 @@ const KollusPlayer = ({
       .then(() => {
         if (onScriptLoaded) {
           onScriptLoaded();
-          setVgController(
-            new window.VgControllerClient({ target_window: (iframeEl.current as HTMLIFrameElement).contentWindow })
-          );
         }
       })
       .catch((error: string) => {
         if (errorHandler) {
           errorHandler(error);
+        }
+      })
+      .finally(() => {
+        if (window.VgControllerClient) {
+          setVgController(
+            new window.VgControllerClient({ target_window: (iframeEl.current as HTMLIFrameElement).contentWindow })
+          );
         }
       });
 

--- a/src/components/player/kollus.tsx
+++ b/src/components/player/kollus.tsx
@@ -33,6 +33,7 @@ const KollusPlayer = ({
   onVolumeChanged,
   onSpeedChanged,
   onSeeked,
+  errorHandler,
   ...restProps
 }: Omit<PlayerProps, 'vendor'>) => {
   const iframeEl = useRef<HTMLIFrameElement | null>(null);
@@ -50,8 +51,8 @@ const KollusPlayer = ({
         }
       })
       .catch((error: string) => {
-        if (error === 'REJECTED: Already Installed' && onScriptLoaded) {
-          onScriptLoaded();
+        if (errorHandler) {
+          errorHandler(error);
         }
       });
 

--- a/src/types/player.interface.ts
+++ b/src/types/player.interface.ts
@@ -18,6 +18,7 @@ export interface PlayerProps {
   onVolumeChanged?: (volume: number) => void;
   onSpeedChanged?: (speed: number) => void;
   onSeeked?: () => void;
+  errorHandler?: (error: any) => void;
 }
 
 export interface PlayerProgress {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 워크플로우 수정
- [ ] 디펜던시 수정
- [ ] 테스트 추가
- [ ] 기타 유지보수

## 관련된 이슈를 이야기해주세요.

- 콜러스 스크립트를 주입하고 vgController생성자를 호출시에, 
onScriptLoaded prop이 있어야만 vgController생성자를 호출하는 현상을 수정합니다.
- 콜러스 스크립트 로드 오류시에는 사용자정의 errorHandler를 실행하도록 변경하였습니다.

## 코드의 실행결과를 볼 수 있는 스크린샷이 있을까요?

## 무엇이 변경되었나요?

- player > errorHandler prop 및 type 추가
- vgController 생성자 호출 시점을 finally로 변경

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
